### PR TITLE
Add two images to media gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
             <iframe class="embed-frame" scrolling="no" src="https://go.screenpal.com/watch/cTQqiJnDVdu?width=100%&height=100%&ff=1&title=0&autoplay=1&muted=1" allowfullscreen allow="autoplay; fullscreen"></iframe>
           </div>
         </div>
+        <div class="image-container">
+          <img class="gallery-image" src="https://cdn.builder.io/api/v1/image/assets%2F29eb5c35f98e4eff9cd0f5e02584e75f%2Fe5c90a5ff396490a95538b08c8e390bd?format=webp&width=800" alt="Attachment e35e89cb">
+        </div>
+        <div class="image-container">
+          <img class="gallery-image" src="https://cdn.builder.io/api/v1/image/assets%2F29eb5c35f98e4eff9cd0f5e02584e75f%2F21fb1673fcd844f4ab4f6ceede00d8c5?format=webp&width=800" alt="Attachment ac1811d9">
+        </div>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,7 @@ header.site-header {
 
 .video-container, .image-container { width: 400px; height: 225px; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.6); overflow: hidden; background: linear-gradient(180deg,#071026,#0b1220); border: 1px solid rgba(255,255,255,0.04); }
 
-.video-container iframe, .image-container iframe { width: 100%; height: 100%; border: 0; }
+.video-container iframe, .image-container iframe, .image-container img.gallery-image { width: 100%; height: 100%; border: 0; object-fit: cover; display: block; }
 
 .embed-frame { border: 0; }
 


### PR DESCRIPTION
## Purpose
The user requested to add a photo and include two images in the media gallery section of the website.

## Code changes
- Added two new image containers to the media gallery section in `index.html`
- Each container includes an `img` element with gallery images from Builder.io CDN
- Updated CSS styles in `styles.css` to properly handle image display within containers
- Added `object-fit: cover` and `display: block` properties to ensure images fill containers properlyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b8c784683c984b58bdeb174accfd30a2/echo-zone)

👀 [Preview Link](https://b8c784683c984b58bdeb174accfd30a2-echo-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b8c784683c984b58bdeb174accfd30a2</projectId>-->
<!--<branchName>echo-zone</branchName>-->